### PR TITLE
Defined explicit .SRT suffix

### DIFF
--- a/changelogs/fragments/11-filenamesuffixcheck.yml
+++ b/changelogs/fragments/11-filenamesuffixcheck.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sapcar_extract.py - more strict logic for filenames

--- a/plugins/modules/files/sapcar_extract.py
+++ b/plugins/modules/files/sapcar_extract.py
@@ -140,10 +140,10 @@ def check_if_present(command, path, dest, signature, manifest, module):
     sar_files = [dest + x.split(" ")[-1] for x in sar_raw if x]
     # remove any SIGNATURE.SMF from list because it will not unpacked if signature is false
     if not signature:
-        sar_files = [item for item in sar_files if '.SMF' not in item]
+        sar_files = [item for item in sar_files if not item.endswith('.SMF')]
     # if signature is renamed manipulate files in list of sar file for compare.
     if manifest != "SIGNATURE.SMF":
-        sar_files = [item for item in sar_files if '.SMF' not in item]
+        sar_files = [item for item in sar_files if not item.endswith('.SMF')]
         sar_files = sar_files + [manifest]
     # get extracted files if present
     files_extracted = get_list_of_files(dest)


### PR DESCRIPTION
##### SUMMARY
We use here more strict rules for filename, i.e. we check if filename ends with something, instead of checking if something is somewhere within certain string (can be somewhere in the middle, for example)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/files/sapcar_extract.py

##### ADDITIONAL INFORMATION
n/a
